### PR TITLE
Add a shared pacts folder to hold contracts between SPA and API

### DIFF
--- a/pacts/spa-api.json
+++ b/pacts/spa-api.json
@@ -1,0 +1,55 @@
+{
+  "consumer": {
+    "name": "SPA"
+  },
+  "provider": {
+    "name": "API"
+  },
+  "interactions": [
+    {
+      "description": "healthcheck",
+      "providerState": "application is healthy",
+      "request": {
+        "method": "GET",
+        "path": "/health"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json; charset=utf-8"
+        },
+        "body": "ok",
+        "matchingRules": {
+          "$.body": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "healthcheck",
+      "providerState": "application is unhealthy",
+      "request": {
+        "method": "GET",
+        "path": "/health"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json; charset=utf-8"
+        },
+        "body": "fail",
+        "matchingRules": {
+          "$.body": {
+            "match": "type"
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    }
+  }
+}


### PR DESCRIPTION
 ## Description

Ideally a Pact broker could be used to mediate between consumers and producers.
At this point there's no such thing, so holding the pact in a shared dir so both can access.